### PR TITLE
Add new 'setPage' and 'drawPage' functions.

### DIFF
--- a/jquery.simplePagination.js
+++ b/jquery.simplePagination.js
@@ -211,13 +211,22 @@
 
 		_selectPage: function(pageIndex, event) {
 			var o = this.data('pagination');
-			o.currentPage = pageIndex;
-			if (o.selectOnClick) {
+			methods.setPage.call(this, pageIndex + 1);
+			return o.onPageClick(pageIndex + 1, event);
+		},
+
+		setPage: function(page, forceDraw) {
+			forceDraw = typeof forceDraw !== 'undefined' ? forceDraw : false;
+			var o = this.data('pagination');
+			o.currentPage = page-1;
+			if (o.selectOnClick || forceDraw) {
 				methods._draw.call(this);
 			}
-			return o.onPageClick(pageIndex + 1, event);
-		}
+		},
 
+		drawPage: function(page) {
+			methods.setPage.call(this, page, true);
+		}
 	};
 	
 	$.fn.pagination = function(method) {


### PR DESCRIPTION
As an alternative to @michael-misshore's patch for drawPage, this also adds a setPage function that will respect selectOnClick. I moved all of the duplicated code from _selectPage into setPage so that drawPage and _selectPage calls the code that is provided in setPage.

This allows you to update the page that is selected without triggering the onPageClick callback.

Also, if you still want selectOnClick to be respected, you can use setPage instead of drawPage. setPage will not redraw the pagination.
