### PR TITLE
Added "nextToFront" option, updated CSS to support

### DIFF
--- a/jquery.simplePagination.js
+++ b/jquery.simplePagination.js
@@ -27,6 +27,7 @@
 				cssStyle: 'light-theme',
 				labelMap: [],
 				selectOnClick: true,
+                nextAtFront: false,
 				onPageClick: function(pageNumber, event) {
 					// Callback triggered when a page is clicked
 					// Page number is given as an optional parameter
@@ -149,6 +150,11 @@
 				methods._appendItem.call(this, o.currentPage - 1, {text: o.prevText, classes: 'prev'});
 			}
 
+            // Generate Next link (if set for front)
+            if (o.nextText && o.nextAtFront) {
+                methods._appendItem.call(this, o.currentPage + 1, {text: o.nextText, classes: 'next'});
+            }
+
 			// Generate start edges
 			if (interval.start > 0 && o.edges > 0) {
 				var end = Math.min(o.edges, interval.start);
@@ -180,8 +186,8 @@
 				}
 			}
 
-			// Generate Next link
-			if (o.nextText) {
+			// Generate Next link (unless it's already at the front)
+			if (o.nextText && !o.nextAtFront) {
 				methods._appendItem.call(this, o.currentPage + 1, {text: o.nextText, classes: 'next'});
 			}
 		},

--- a/simplePagination.css
+++ b/simplePagination.css
@@ -40,7 +40,7 @@ ul.simple-pagination {
 	font-weight: normal;
 	text-align: center;
 	border: 1px solid #AAA;
-	border-right: none;
+	border-left: none;
 	min-width: 14px;
 	padding: 0 7px;
 	box-shadow: 2px 2px 2px rgba(0,0,0,0.2);
@@ -64,12 +64,12 @@ ul.simple-pagination {
 	background: linear-gradient(top, #efefef 0%,#bbbbbb 100%); /* W3C */
 }
 
-.compact-theme .prev {
+.compact-theme li:first-child a, .compact-theme li:first-child span {
+	border-left: 1px solid #AAA;
 	border-radius: 3px 0 0 3px;
 }
 
-.compact-theme .next {
-	border-right: 1px solid #AAA;
+.compact-theme li:last-child a, .compact-theme li:last-child span {
 	border-radius: 0 3px 3px 0;
 }
 


### PR DESCRIPTION
CSS updates were only on the compact-theme, everything else didn't need any modification.

Instead of applying border radii to .prev and .next, I simply made it on the first and last list element.
This is because .next may not be at the end anymore.

With this new styling, it also supports the case that .prev or .next DON'T exist, for instance
when the user explicitly removes them (by setting prevText or nextText to false/"" on initialisation).

Regarding CSS browser compatibility, :last-child may not be supported on older browsers, however, it
definitely will be supported by any browser that supports border radius. i.e. if :last-child is NOT supported
then neither is border radius, and hence we're not losing anything.

Considering the use of :last-child, compact-theme took a shift from having border-right: none; to
border-left: none. Now instead of having the border set explicitly for the last child to account for that
missing edge, it's now on the first child (which has wider CSS support, down to IE7) and appropriately border-left.
