### PR TITLE
Added nextAtFront option

### DIFF
--- a/jquery.simplePagination.js
+++ b/jquery.simplePagination.js
@@ -27,6 +27,7 @@
 				cssStyle: 'light-theme',
 				labelMap: [],
 				selectOnClick: true,
+				nextAtFront: false,
 				onPageClick: function(pageNumber, event) {
 					// Callback triggered when a page is clicked
 					// Page number is given as an optional parameter
@@ -149,6 +150,11 @@
 				methods._appendItem.call(this, o.currentPage - 1, {text: o.prevText, classes: 'prev'});
 			}
 
+			// Generate Next link (if option set for at front)
+			if (o.nextText && o.nextAtFront) {
+				methods._appendItem.call(this, o.currentPage + 1, {text: o.nextText, classes: 'next'});
+			}
+
 			// Generate start edges
 			if (interval.start > 0 && o.edges > 0) {
 				var end = Math.min(o.edges, interval.start);
@@ -180,8 +186,8 @@
 				}
 			}
 
-			// Generate Next link
-			if (o.nextText) {
+			// Generate Next link (unless option is set for at front)
+			if (o.nextText && !o.nextAtFront) {
 				methods._appendItem.call(this, o.currentPage + 1, {text: o.nextText, classes: 'next'});
 			}
 		},

--- a/simplePagination.css
+++ b/simplePagination.css
@@ -40,7 +40,7 @@ ul.simple-pagination {
 	font-weight: normal;
 	text-align: center;
 	border: 1px solid #AAA;
-	border-right: none;
+	border-left: none;
 	min-width: 14px;
 	padding: 0 7px;
 	box-shadow: 2px 2px 2px rgba(0,0,0,0.2);
@@ -64,12 +64,12 @@ ul.simple-pagination {
 	background: linear-gradient(top, #efefef 0%,#bbbbbb 100%); /* W3C */
 }
 
-.compact-theme .prev {
+.compact-theme li:first-child a, .compact-theme li:first-child span {
+	border-left: 1px solid #AAA;
 	border-radius: 3px 0 0 3px;
 }
 
-.compact-theme .next {
-	border-right: 1px solid #AAA;
+.compact-theme li:last-child a, .compact-theme li:last-child span {
 	border-radius: 0 3px 3px 0;
 }
 


### PR DESCRIPTION
The nextAtFront option will make the pagination look like..:

Prev Next 1 2 3 4 5
instead of:
Prev 1 2 3 4 5 Next

A couple of gentle CSS changes were made in the compact-theme to support this:

.compact-theme .prev -> .compact-theme li:first-child a, .compact-theme li:first-child span
.compact-theme .next -> .compact-theme li:last-child a, .compact-theme li:last-child span
These changes were made for two reasons:
1) .next is not necessarily the last child (especially with the nextAtFront option), so the
   border radius needs to be applied to whatever is the last child.
2) If prevText or nextText was set to false or "" then they wouldn't be displayed and the
   border radius wouldn't have been applied to any list item, making the compact theme look
   crazy.

border-right: none           -> border-left: none
border-right: 1px solid #AAA -> border-left: 1px solid #AAA
This change was made as a CSS compatibility concern:
Now that it's moved from border-right to border-left: none, if :last-child happened to not
be supported (as it's considered CSS3 whereas :first-child is CSS2 - more widely supported),
we'll see no breakage in the borders.
Even if :last-child is not supported, we won't notice any difference at all because the only
property being applied in there is border radius, and, if :last-child isn't supported then
neither was border radius, so the result would be exactly the same as the old .next CSS.
