### PR TITLE
Add new 'setPage' and 'drawPage' functions.

### DIFF
--- a/jquery.simplePagination.js
+++ b/jquery.simplePagination.js
@@ -103,14 +103,6 @@
 			return this;
 		},
 
-		drawPage: function (page) {
-			var o = this.data('pagination');
-			o.currentPage = page - 1;
-			this.data('pagination', o);
-			methods._draw.call(this);
-			return this;
-		},
-
 		redraw: function(){
 			methods._draw.call(this);
 			return this;
@@ -306,7 +298,7 @@
 		setPage: function(page, forceDraw) {
 			forceDraw = typeof forceDraw !== 'undefined' ? forceDraw : false;
 			var o = this.data('pagination');
-			o.currentPage = page-1;
+			o.currentPage = page - 1;
 			if (o.selectOnClick || forceDraw) {
 				methods._draw.call(this);
 			}


### PR DESCRIPTION
As an alternative to @michael-misshore's patch for drawPage, this also adds a setPage function that will respect selectOnClick. I moved all of the duplicated code from _selectPage into setPage so that drawPage and _selectPage calls the code that is provided in setPage.

This allows you to update the page that is selected without triggering the onPageClick callback.

Also, if you still want selectOnClick to be respected, you can use setPage instead of drawPage. setPage will not redraw the pagination.

Note: This patch has been rebased, and @michael-misshore's original drawPage function removed.
