### PR TITLE
added condition to support none href modification 

### DIFF
--- a/jquery.simplePagination.js
+++ b/jquery.simplePagination.js
@@ -290,7 +290,11 @@
 				}
 				$link = $('<span class="current">' + (options.text) + '</span>');
 			} else {
-				$link = $('<a href="' + o.hrefTextPrefix + (pageIndex + 1) + o.hrefTextSuffix + '" class="page-link">' + (options.text) + '</a>');
+            if (o.hrefTextPrefix){
+               $link = $('<a href="' + o.hrefTextPrefix + (pageIndex + 1) + o.hrefTextSuffix + '" class="page-link">' + (options.text) + '</a>');
+            }else{
+               $link = $('<a href="javascript:void(0)" class="page-link">' + (options.text) + '</a>');
+            }
 				$link.click(function(event){
 					return methods._selectPage.call(self, pageIndex, event);
 				});


### PR DESCRIPTION
This is for compatibility with routing single page applications.
By setting hrefTextPrefix to null the paging links can have href set to 'javascript:void(0)'
