### PR TITLE
Allow setting page count after creation

### DIFF
--- a/jquery.simplePagination.js
+++ b/jquery.simplePagination.js
@@ -96,6 +96,10 @@
 			return this.data('pagination').pages;
 		},
 
+		setPagesCount: function(count) {
+			this.data('pagination').pages = count;
+		},
+
 		getCurrentPage: function () {
 			return this.data('pagination').currentPage + 1;
 		},


### PR DESCRIPTION
There are dynamic methods to set items/itemsPerPage and to get current page count, but not to set current page count (if you're explicitly managing pages yourself rather than using items/itemsPerPage). So, added one.