### PR TITLE
hideSingle option hides pagination if there's only one page of results

### DIFF
--- a/jquery.simplePagination.js
+++ b/jquery.simplePagination.js
@@ -23,6 +23,7 @@
 				hrefTextSuffix: '',
 				prevText: 'Prev',
 				nextText: 'Next',
+				hideSingle: true,
 				ellipseText: '&hellip;',
 				cssStyle: 'light-theme',
 				labelMap: [],
@@ -156,6 +157,9 @@
 				interval = methods._getInterval(o),
 				i,
 				tagName;
+			if (o.items <= o.itemsOnPage && o.hideSingle) {
+				return;
+			}
 
 			methods.destroy.call(this);
 			


### PR DESCRIPTION
Your library saved me lots of time! With the savings, I added an option I wanted -- hide pagination if there is only one page of items. It's not fancy, but it works.
