### PR TITLE
Add new 'setPage' and 'drawPage' functions.

### DIFF
--- a/jquery.simplePagination.js
+++ b/jquery.simplePagination.js
@@ -105,12 +105,18 @@
 			return this;
 		},
 
-		drawPage: function (page) {
+		drawPage: function(page) {
+			methods.setPage.call(this, page, true);
+		},
+
+		setPage: function (page, forceDraw) {
+			forceDraw = typeof forceDraw !== 'undefined' ? forceDraw : false;
 			var o = this.data('pagination');
 			o.currentPage = page - 1;
-			this.data('pagination', o);
-			methods._draw.call(this);
-			return this;
+			if (o.selectOnClick || forceDraw) {
+				methods._draw.call(this);
+			}
+			return o.onPageClick(pageIndex + 1, event);
 		},
 
 		redraw: function(){
@@ -312,9 +318,7 @@
 		_selectPage: function(pageIndex, event) {
 			var o = this.data('pagination');
 			o.currentPage = pageIndex;
-			if (o.selectOnClick) {
-				methods._draw.call(this);
-			}
+			methods._draw.call(this);
 			return o.onPageClick(pageIndex + 1, event);
 		}
 


### PR DESCRIPTION
This also adds a setPage function that will respect selectOnClick. I moved all of the duplicated code from _selectPage into setPage so that drawPage and _selectPage calls the code that is provided in setPage.

This allows you to update the page that is selected without triggering the onPageClick callback.

Also, if you still want selectOnClick to be respected, you can use setPage instead of drawPage. setPage will not redraw the pagination.

I have greatly cleaned up this patch :), so this is a much better alternative to #76.