### PR TITLE
FIXES #101 Add option to hide page-link href

### DIFF
--- a/jquery.simplePagination.js
+++ b/jquery.simplePagination.js
@@ -19,6 +19,7 @@
 				displayedPages: 5,
 				edges: 2,
 				currentPage: 0,
+				hasHref: true,
 				hrefTextPrefix: '#page-',
 				hrefTextSuffix: '',
 				prevText: 'Prev',
@@ -290,7 +291,7 @@
 				}
 				$link = $('<span class="current">' + (options.text) + '</span>');
 			} else {
-				$link = $('<a href="' + o.hrefTextPrefix + (pageIndex + 1) + o.hrefTextSuffix + '" class="page-link">' + (options.text) + '</a>');
+				$link = $('<a href="' + ( o.hasHref ? ( o.hrefTextPrefix + (pageIndex + 1) + o.hrefTextSuffix ) : 'javascript:void(0);' )  + '" class="page-link">' + (options.text) + '</a>');
 				$link.click(function(event){
 					return methods._selectPage.call(self, pageIndex, event);
 				});


### PR DESCRIPTION
FIXES #101. This allows the page-link href to have a value of `javascript:void(0)` instead. If you feel that this change is not necessary then please do feel free to close.