### PR TITLE
Add ellipsePageSet option

### DIFF
--- a/jquery.simplePagination.js
+++ b/jquery.simplePagination.js
@@ -24,6 +24,7 @@
 				prevText: 'Prev',
 				nextText: 'Next',
 				ellipseText: '&hellip;',
+				ellipsePageSet: true,
 				cssStyle: 'light-theme',
 				listStyle: '',
 				labelMap: [],
@@ -167,7 +168,7 @@
 				tagName;
 
 			methods.destroy.call(this);
-			
+
 			tagName = (typeof this.prop === 'function') ? this.prop('tagName') : this.attr('tagName');
 
 			var $panel = tagName === 'UL' ? this : $('<ul' + (o.listStyle ? ' class="' + o.listStyle + '"' : '') + '></ul>').appendTo(this);
@@ -261,6 +262,11 @@
 			if (o.nextText && !o.nextAtFront) {
 				methods._appendItem.call(this, !o.invertPageOrder ? o.currentPage + 1 : o.currentPage - 1, {text: o.nextText, classes: 'next'});
 			}
+
+			if (o.ellipsePageSet && !o.disabled) {
+				methods._ellipseClick.call(this, $panel);
+			}
+
 		},
 
 		_getPages: function(o) {
@@ -325,6 +331,47 @@
 				methods._draw.call(this);
 			}
 			return o.onPageClick(pageIndex + 1, event);
+		},
+
+
+		_ellipseClick: function($panel) {
+			var self = this,
+				o = this.data('pagination'),
+				$ellip = $panel.find('.ellipse');
+			$ellip.addClass('clickable').parent().removeClass('disabled');
+			$ellip.click(function(event) {
+				if (!o.disable) {
+					var $this = $(this),
+						val = (parseInt($this.parent().prev().text(), 10) || 0) + 1;
+					$this
+						.html('<input type="number" min="1" max="' + o.pages + '" step="1" value="' + val + '">')
+						.find('input')
+						.focus()
+						.click(function(event) {
+							// prevent input number arrows from bubbling a click event on $ellip
+							event.stopPropagation();
+						})
+						.keyup(function(event) {
+							var val = $(this).val();
+							if (event.which === 13 && val !== '') {
+								// enter to accept
+								methods._selectPage.call(self, val - 1);
+							} else if (event.which === 27) {
+								// escape to cancel
+								$ellip.empty().html(o.ellipseText);
+							}
+						})
+						.bind('blur', function(event) {
+							var val = $(this).val();
+							if (val !== '') {
+								methods._selectPage.call(self, val - 1);
+							}
+							$ellip.empty().html(o.ellipseText);
+							return false;
+						});
+				}
+				return false;
+			});
 		}
 
 	};

--- a/simplePagination.css
+++ b/simplePagination.css
@@ -27,6 +27,13 @@ ul.simple-pagination {
 	margin: 0;
 	float: left;
 }
+span.ellipse.clickable {
+	cursor: pointer;
+}
+
+.ellipse input {
+	width: 3em;
+}
 
 /*------------------------------------*\
 	Compact Theme Styles


### PR DESCRIPTION
When this option is `true`, clicking on the ellipse will replace the ellipse with a number type input in which you can manually set the resulting page.

Try the change in this demo: http://jsbin.com/vibasaluci/edit?output

* Click on any ellipse
* Change the target page by typing in the destination, or using the up/down number input buttons.
* Press <kbd>Enter</kbd> or blur the input to trigger the page change.
* Press <kbd>Esc</kbd>, or clear then blur the input, to cancel the change.

I didn't add any unit tests for these changes, but all tests still pass.